### PR TITLE
Fix the roccat driver and add some tests for it

### DIFF
--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -574,6 +574,7 @@ class Profile(Feature):
         capabilities=(),
         report_rate=None,
         report_rates=(),
+        active=False,
     ):
         super().__init__(device, index)
         self.name = f"Unnamed {index}" if name is None else name
@@ -581,7 +582,7 @@ class Profile(Feature):
         self._resolutions = ()
         self._leds = ()
         self._default = False
-        self._active = False
+        self._active = active
         self._enabled = True
         self._report_rate = report_rate
         self._report_rates = tuple(set(report_rates))

--- a/ratbag/drivers/__init__.py
+++ b/ratbag/drivers/__init__.py
@@ -173,20 +173,20 @@ class Rodent(GObject.Object):
         else:
             return device
 
-    def __init__(self, path):
+    def __init__(self, path=None):
         GObject.Object.__init__(self)
-        self.path = path
 
-        info = ratbag.util.load_device_info(path)
-        self.name = info["name"] or "Unnamed device"
-        self.report_descriptor = info.get("report_descriptor", None)
-        if self.report_descriptor is not None:
-            self._rdesc = hidtools.hid.ReportDescriptor.from_bytes(
-                self.report_descriptor
-            )
+        if path is not None:
+            self.path = path
+            info = ratbag.util.load_device_info(path)
+            self.name = info["name"] or "Unnamed device"
+            self.report_descriptor = info.get("report_descriptor", None)
+            self._fd = open(path, "r+b", buffering=0)
+            os.set_blocking(self._fd.fileno(), False)
 
-        self._fd = open(path, "r+b", buffering=0)
-        os.set_blocking(self._fd.fileno(), False)
+        rdesc = getattr(self, "report_descriptor", None)
+        if rdesc is not None:
+            self._rdesc = hidtools.hid.ReportDescriptor.from_bytes(rdesc)
 
     @property
     def report_ids(self):

--- a/ratbag/drivers/__init__.py
+++ b/ratbag/drivers/__init__.py
@@ -89,6 +89,7 @@ class Rodent(GObject.Object):
         The bytes for this hidraw device's report descriptor (if this device
         is a hidraw device, otherwise ``None``)
 
+
     GObject Signals:
         - ``data-to-device``, ``data-from-device``: the ``bytes`` that have
           been written to or read from the device.
@@ -186,6 +187,20 @@ class Rodent(GObject.Object):
 
         self._fd = open(path, "r+b", buffering=0)
         os.set_blocking(self._fd.fileno(), False)
+
+    @property
+    def report_ids(self):
+        """
+        A dictionary containg the list each of "feature", "input" and "output"
+        report IDs. For devices without a report descriptor, each list is
+        empty.
+        """
+        ids = {"input": [], "output": [], "feature": []}
+        if self.report_descriptor is not None:
+            ids["input"] = self._rdesc.input_reports
+            ids["output"] = self._rdesc.output_reports
+            ids["feature"] = self._rdesc.feature_reports
+        return ids
 
     def start(self):
         """

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -219,8 +219,7 @@ class RoccatMacro(object):
         ("<H", "checksum"),
     ]
 
-    def __init__(self, mapping, button_idx):
-        self.mapping = mapping
+    def __init__(self, button_idx):
         self.button = button_idx
         self.name = f"macro on {button_idx}"
         self.keys = 500 * [(0, 0, 0)]  # A triple of keycode, flags, wait_time
@@ -582,7 +581,7 @@ class RoccatDevice(GObject.Object):
 
                 logger.debug(f"ioctl {ReportID.MACRO.name} for button {idx}.{bidx}")
                 bs = self.hidraw_device.hid_get_feature(ReportID.MACRO)
-                macro = RoccatMacro(mapping, bidx).from_data(bytes(bs))
+                macro = RoccatMacro(bidx).from_data(bytes(bs))
                 mapping.macros[bidx] = macro
 
             self.profiles.append(profile)

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -703,6 +703,7 @@ class RoccatDriver(ratbag.drivers.Driver):
         except ratbag.ProtocolError as e:
             e.name = roccat_device.name
             e.path = roccat_device.path
+            raise e
 
 
 def load_driver(driver_name):

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -104,7 +104,7 @@ class RoccatProfile(object):
         self.ratbag_profile = None
         self.key_mapping = None
         ratbag.util.attr_from_data(
-            self, RoccatProfile.format, bytes([0] * RoccatProfile.SIZE)
+            self, RoccatProfile.format, bytes([0] * RoccatProfile.SIZE), quiet=True
         )
         self.report_id = ReportID.PROFILE_SETTINGS.value
         self.report_length = RoccatProfile.SIZE
@@ -224,7 +224,7 @@ class RoccatMacro(object):
     def __init__(self, profile_idx, button_idx):
         # Init everything with zeroes so we have all attributes we need
         ratbag.util.attr_from_data(
-            self, RoccatMacro.format, bytes([0x00] * RoccatMacro.SIZE)
+            self, RoccatMacro.format, bytes([0x00] * RoccatMacro.SIZE), quiet=True
         )
         self.report_id = ReportID.MACRO.value
         self.report_length = RoccatMacro.SIZE

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -414,8 +414,8 @@ class RoccatKeyMapping(object):
         39: ratbag.hid.ConsumerControl.CC_VOLUME_DOWN,
     }
 
-    def __init__(self, profile):
-        self.profile = profile
+    def __init__(self, profile_idx):
+        self.profile_id = profile_idx
         self.macros = {}  # button index: RoccatMacro
         self.num_buttons = MAX_BUTTONS
         self.report_id = ReportID.KEY_MAPPING.value
@@ -431,7 +431,7 @@ class RoccatKeyMapping(object):
         ratbag.util.attr_from_data(self, RoccatKeyMapping.format, data, offset=0)
         if crc(data) != self.checksum:
             raise ratbag.ProtocolError(
-                f"CRC validation failed for mapping on {self.profile.idx}"
+                f"CRC validation failed for mapping on {self.profile_id}"
             )
         return self  # to allow for chaining
 
@@ -473,7 +473,7 @@ class RoccatKeyMapping(object):
             # For keycodes we pretend it's a macro
             assert macro is None
             try:
-                macro = RoccatMacro(self.profile.idx, idx)
+                macro = RoccatMacro(self.profile_id, idx)
                 keycode = RoccatKeyMapping.keycodes[action]
                 macro.name = "keycode"
                 macro.keys = [
@@ -592,7 +592,7 @@ class RoccatDevice(GObject.Object):
             self.set_config_profile(idx, ConfigureCommand.KEY_MAPPING)
             logger.debug(f"ioctl {ReportID.KEY_MAPPING.name} for profile {idx}")
             bs = self.hidraw_device.hid_get_feature(ReportID.KEY_MAPPING)
-            mapping = RoccatKeyMapping(profile).from_data(bytes(bs))
+            mapping = RoccatKeyMapping(profile.idx).from_data(bytes(bs))
             profile.key_mapping = mapping
 
             # Macros are in a separate HID Report, fetch those and store them

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -681,7 +681,6 @@ class RoccatDevice(GObject.Object):
 class RoccatDriver(ratbag.drivers.Driver):
     def __init__(self):
         super().__init__()
-        self.device = None  # the roccat device
 
     def probe(self, device, info, config):
         hidraw_device = ratbag.drivers.Rodent.from_device(device)
@@ -696,9 +695,9 @@ class RoccatDriver(ratbag.drivers.Driver):
             hidraw_device.connect_to_recorder(rec)
             rec.init(
                 {
-                    "name": self.device.name,
+                    "name": device.name,
                     "driver": "roccat",
-                    "path": self.device.path,
+                    "path": device.path,
                     "report_descriptor": self.hidraw_device.report_descriptor,
                 }
             )

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -108,6 +108,8 @@ class RoccatProfile(object):
         self.active = False
         self.ratbag_profile = None
         self.key_mapping = None
+        self.report_id = ReportID.SETTINGS.value
+        self.report_length = RoccatProfile.SIZE
 
     def from_data(self, data):
         if len(data) != RoccatProfile.SIZE:
@@ -226,6 +228,8 @@ class RoccatMacro(object):
         self.keys = 500 * [(0, 0, 0)]  # A triple of keycode, flags, wait_time
         self.length = 0
         self._macro_exists_on_device = False
+        self.report_id = ReportID.MACRO.value
+        self.report_length = RoccatMacro.SIZE
 
     def to_ratbag(self):
         events = []
@@ -396,6 +400,8 @@ class RoccatKeyMapping(object):
         self.profile = profile
         self.macros = {}  # button index: RoccatMacro
         self.num_buttons = MAX_BUTTONS
+        self.report_id = ReportID.KEY_MAPPING.value
+        self.report_length = RoccatKeyMapping.SIZE
 
     def from_data(self, data):
         if len(data) != RoccatKeyMapping.SIZE:

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -530,6 +530,7 @@ class RoccatKeyMapping(object):
                 else:
                     action = 48  # it's a macro
             self.macros[idx] = macro
+        self.actions[idx] = (action, 0, 0)
 
     def __bytes__(self):
         # Weirdly enough, our first KeyMapping reply has a length of zero

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -52,7 +52,7 @@ class ReportID(enum.IntEnum):
     """
 
     CONFIGURE_PROFILE = 0x4
-    PROFILE = 0x5
+    CURRENT_PROFILE = 0x5
     SETTINGS = 0x6
     KEY_MAPPING = 0x7
     MACRO = 8
@@ -545,7 +545,7 @@ class RoccatDevice(GObject.Object):
             )
 
         # Featch current profile index
-        logger.debug(f"ioctl {ReportID.PROFILE.name}")
+        logger.debug(f"ioctl {ReportID.CURRENT_PROFILE.name}")
         bs = self.hidraw_device.hid_get_feature(ReportID.PROFILE)
         current_profile_idx = bs[2]
         logger.debug(f"current profile is {current_profile_idx}")

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -103,6 +103,9 @@ class RoccatProfile(object):
         self.active = False
         self.ratbag_profile = None
         self.key_mapping = None
+        ratbag.util.attr_from_data(
+            self, RoccatProfile.format, bytes([0] * RoccatProfile.SIZE)
+        )
         self.report_id = ReportID.PROFILE_SETTINGS.value
         self.report_length = RoccatProfile.SIZE
 

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -147,6 +147,7 @@ class RoccatProfile(object):
             capabilities=caps,
             report_rate=self.report_rate,
             report_rates=[125, 250, 500, 1000],  # Not sure we can query this
+            active=self.active,
         )
         for (dpi_idx, dpi) in enumerate(self.dpi):
             dpi_list = list(range(200, 8200 + 1, 50))

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -550,7 +550,7 @@ class RoccatDevice(GObject.Object):
                 self.name, self.path, "ConfigureProfile Report ID"
             )
 
-        # Featch current profile index
+        # Fetch current profile index
         logger.debug(f"ioctl {ReportID.CURRENT_PROFILE.name}")
         bs = self.hidraw_device.hid_get_feature(ReportID.CURRENT_PROFILE)
         current_profile_idx = bs[2]

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -11,10 +11,6 @@ import struct
 import time
 import traceback
 
-import hidtools
-import hidtools.hidraw
-import hidtools.hid
-
 from gi.repository import GObject
 
 import ratbag
@@ -538,14 +534,12 @@ class RoccatDevice(GObject.Object):
         return self.hidraw_device.path
 
     def start(self):
-        rdesc = hidtools.hid.ReportDescriptor.from_bytes(
-            self.hidraw_device.report_descriptor
-        )
-        if ReportID.KEY_MAPPING not in rdesc.feature_reports:
+        feature_reports = self.hidraw_device.report_ids["feature"]
+        if ReportID.KEY_MAPPING not in feature_reports:
             raise ratbag.SomethingIsMissingError(
                 self.name, self.path, "KeyMapping Report ID"
             )
-        if ReportID.CONFIGURE_PROFILE not in rdesc.feature_reports:
+        if ReportID.CONFIGURE_PROFILE not in feature_reports:
             raise ratbag.SomethingIsMissingError(
                 self.name, self.path, "ConfigureProfile Report ID"
             )

--- a/ratbag/util.py
+++ b/ratbag/util.py
@@ -186,7 +186,7 @@ def attr_from_data(obj, fmt_tuples, data, offset=0, quiet=False):
             assert groupcount > 1
 
         count = len(fmt)
-        for _ in range(groupcount):
+        for group_index in range(groupcount):
             val = struct.unpack_from(endian + fmt, data, offset=offset)
             sz = struct.calcsize(fmt)
             if name == "_":
@@ -198,9 +198,10 @@ def attr_from_data(obj, fmt_tuples, data, offset=0, quiet=False):
                     val = val[0]
                 if groupcount > 1:
                     debugstr = f"self.{name:24s} += {val}"
-                    attr = getattr(obj, name, [])
+                    if group_index == 0:
+                        setattr(obj, name, [])
+                    attr = getattr(obj, name)
                     attr.append(val)
-                    setattr(obj, name, attr)
                 else:
                     debugstr = f"self.{name:24s} = {val}"
                     setattr(obj, name, val)

--- a/ratbag/util.py
+++ b/ratbag/util.py
@@ -133,7 +133,7 @@ def load_device_info(devnode):
     return info
 
 
-def attr_from_data(obj, fmt_tuples, data, offset=0):
+def attr_from_data(obj, fmt_tuples, data, offset=0, quiet=False):
     """
     ``fmt_tuples`` is a list of tuples that are converted into attributes on
     ``obj``. Each entry is a tuple in the form ``(format, fieldname)`` where
@@ -167,7 +167,8 @@ def attr_from_data(obj, fmt_tuples, data, offset=0):
     :returns: the new offset after parsing all tuples
     """
 
-    logger_autoparse.debug(f"parsing {type(obj).__name__}: {as_hex(data)}")
+    if not quiet:
+        logger_autoparse.debug(f"parsing {type(obj).__name__}: {as_hex(data)}")
 
     endian = ">"  # default to BE
 
@@ -203,9 +204,10 @@ def attr_from_data(obj, fmt_tuples, data, offset=0):
                 else:
                     debugstr = f"self.{name:24s} = {val}"
                     setattr(obj, name, val)
-            logger_autoparse.debug(
-                f"offset {offset:02d}: {as_hex(data[offset:offset+sz]):5s} → {debugstr}"
-            )
+            if not quiet:
+                logger_autoparse.debug(
+                    f"offset {offset:02d}: {as_hex(data[offset:offset+sz]):5s} → {debugstr}"
+                )
             offset += sz
 
     return offset

--- a/tests/test_roccat.py
+++ b/tests/test_roccat.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: MIT
+#
+# This file is formatted with Python Black
+#
+
+import libevdev
+import logging
+import pytest
+
+from gi.repository import GLib
+
+import ratbag.drivers
+import ratbag.drivers.roccat as roccat
+from ratbag.util import as_hex
+
+logger = logging.getLogger(__name__)
+
+# From a  Roccat Kone XTD
+ROCCAT_HID_REPORT = bytes(
+    int(x, 16)
+    for x in """
+05 01 09 02 a1 01 85 01 09 01 a1 00 05 09 19 01 29 05
+15 00 25 01 95 05 75 01 81 02 75 03 95 01 81 03 05 01 09 30 09 31 16 00 80 26
+ff 7f 95 02 75 10 81 06 09 38 15 81 25 7f 75 08 95 01 81 06 05 0c 0a 38 02 81
+06 c0 c0 05 0c 09 01 a1 01 85 02 19 00 2a 3c 02 15 00 26 3c 02 95 01 75 10 81
+00 c0 05 0a 09 00 a1 01 85 03 19 00 29 00 15 00 25 00 95 04 75 08 81 00 c0 05
+0b 09 00 a1 01 85 04 19 00 29 00 15 00 25 00 95 02 75 08 b1 01 85 05 95 02 b1
+01 85 06 95 2a b1 01 85 07 95 4c b1 01 85 08 96 21 08 b1 01 85 09 95 05 b1 01
+85 0a 95 07 b1 01 85 0c 95 03 b1 01 85 0d 96 03 04 b1 01 85 0e 95 02 b1 01 85
+0f 95 05 b1 01 85 10 95 0f b1 01 85 1a 96 04 04 b1 01 85 1b 96 01 04 b1 01 85
+1c 95 02 b1 01 c0
+""".strip()
+    .replace("\n", " ")
+    .split(" ")
+)
+
+
+class RoccatTestDevice(ratbag.drivers.Rodent):
+    class Profile:
+        """
+        Use for software-configuring the device
+        """
+
+        def __init__(self):
+            self.buttons = list(
+                range(1, roccat.MAX_BUTTONS + 2)
+            )  # button actions, indexed by 1
+            self.resolutions = list(
+                map(lambda x: x * 100, range(5, 11))
+            )  # 500 - 1000dpi
+            self.macros = [None] * len(self.buttons)
+
+    """
+    This is effectively a software emulation of a roccat device supported by
+    that driver. It follows the implementation closely since that's what we
+    have, it's purpose is *not* to figure out how the actual device work, it's
+    purpose is solely to make sure that the driver still works if we refactor
+    ratbag or the driver itself.
+    """
+
+    def __init__(self):
+        self.report_descriptor = ROCCAT_HID_REPORT
+        super().__init__()
+        self.name = f"{type(self).__name__}"
+        self.path = "/testdevice"
+        # See hid_set_select_profile
+        self.current_profile = 0
+        self.subcommand = None
+        # Default button actions: 1, 2, 3, etc.
+        # This is currently not per-profile though
+        self.profiles = [RoccatTestDevice.Profile() for _ in range(roccat.MAX_PROFILES)]
+        self.active_profile = 0
+
+    def hid_get_feature(self, report_id):
+        try:
+            name = roccat.ReportID(report_id).name
+        except ValueError:
+            name = "unnamed request"
+        logger.info(f"GetFeature: {report_id:02x} {name}")
+        reply = {
+            roccat.ReportID.SELECT_PROFILE.value: self.hid_get_select_profile,
+            roccat.ReportID.CURRENT_PROFILE.value: self.hid_get_current_profile,
+            roccat.ReportID.PROFILE_SETTINGS.value: self.hid_get_profile_settings,
+            roccat.ReportID.KEY_MAPPING.value: self.hid_get_key_mapping,
+            roccat.ReportID.MACRO.value: self.hid_get_macro,
+        }[report_id]()
+        logger.info(f"GetFeature:    → {as_hex(reply)}")
+        return reply
+
+    def hid_set_feature(self, report_id, data):
+        try:
+            name = roccat.ReportID(report_id).name
+        except ValueError:
+            name = "unnamed request"
+        logger.info(f"SetFeature: {report_id:02x} {name} {as_hex(data)}")
+        return {
+            roccat.ReportID.SELECT_PROFILE.value: self.hid_set_select_profile,
+            # roccat.ReportID.CURRENT_PROFILE.value: self.hid_set_current_profile,
+            roccat.ReportID.PROFILE_SETTINGS.value: self.hid_set_profile_settings,
+            roccat.ReportID.KEY_MAPPING.value: self.hid_set_key_mapping,
+            # roccat.ReportID.MACRO.value: self.hid_set_macro,
+        }[report_id](data)
+
+    def hid_get_current_profile(self):
+        return bytes([roccat.ReportID.CURRENT_PROFILE.value, self.active_profile, 0])
+
+    def hid_get_select_profile(self):
+        # get feature on this report ID replies wether the device is ready
+        # 0x1 means everything ok (so we don't busy wait)
+        return bytes([roccat.ReportID.SELECT_PROFILE.value, 0x1, 0])
+
+    def hid_set_select_profile(self, data):
+        # This set feature decides what we do next for the various get
+        # features later. byte[1] is the profile ID, byte[2] is what we want
+        # to get next
+        self.current_profile = data[1]
+        self.subcommand = data[2]
+        logger.debug(
+            f"Selected profile {self.current_profile}, subcommand {self.subcommand}"
+        )
+
+    def hid_get_profile_settings(self):
+        # Ensure we've switched to the right subcommand in a previous select
+        # profile call
+        assert self.subcommand == roccat.ConfigureCommand.SETTINGS.value
+        assert self.current_profile < roccat.MAX_PROFILES
+
+        # RoccatProfile sets report id and length for us
+        profile = roccat.RoccatProfile(0)
+        profile.profile_id = self.current_profile
+        profile.x_sensitivity = 0
+        profile.y_sensitivity = 0
+        profile.xy_linked = False
+        profile.current_dpi = 0
+        profile.update_report_rate(500)
+        for idx, dpi in enumerate([800] * 5):
+            profile.update_dpi(idx, (800, 800), True)
+        return bytes(profile)
+
+    def hid_set_profile_settings(self, data):
+        profile = roccat.RoccatProfile(0).from_data(data)
+        profile.index = profile.profile_id
+        self.profiles[profile.index].resolutions = [
+            (x * 50, y * 50) for x, y in zip(profile.xres, profile.yres)
+        ]
+        # FIXME: a few bits missing here
+
+    def hid_get_key_mapping(self):
+        # Ensure we've switched to the right subcommand in a previous select
+        # profile call
+        assert self.subcommand == roccat.ConfigureCommand.KEY_MAPPING.value
+        assert self.current_profile < roccat.MAX_PROFILES
+
+        mapping = roccat.RoccatKeyMapping(0)
+        mapping.profile_id = self.current_profile
+        mapping.actions = tuple(
+            map(lambda x: (x, 0, 0), self.profiles[self.current_profile].buttons)
+        )
+        return bytes(mapping)
+
+    def hid_set_key_mapping(self, data):
+        mapping = roccat.RoccatKeyMapping(0).from_data(data)
+        for idx, k in enumerate(mapping.actions):
+            self.profiles[mapping.profile_id].buttons[idx] = k[0]
+
+    def hid_get_macro(self):
+        # Subcommond is supposed to be the button index
+        assert self.subcommand < roccat.MAX_BUTTONS
+        assert self.current_profile < roccat.MAX_PROFILES
+        macro = roccat.RoccatMacro(self.current_profile, self.subcommand)
+        mconfig = self.profiles[self.current_profile].macros[self.subcommand]
+        for idx, m in enumerate(mconfig):
+            macro.update_key(idx, m)
+        return bytes(macro)
+
+
+@pytest.fixture
+def driver():
+    return roccat.load_driver("roccat")
+
+
+def test_load_driver():
+    # the most basic test case...
+    assert roccat.load_driver("roccat") is not None
+    with pytest.raises(AssertionError):
+        roccat.load_driver("wrong-name")
+
+
+class TestRoccatDriver(object):
+    def mainloop(self):
+        ctx = GLib.MainContext.default()
+        while ctx.pending():
+            ctx.iteration(False)
+
+    def cb_device_added(self, ratbag, device):
+        logger.info(f"Adding device {device.name}")
+        self.ratbag_device = device
+
+    def test_init_device_defaults(self, driver):
+        # The most basic test, start a device, check the various default values
+        # **we** define for this device (not the driver)
+        dev = RoccatTestDevice()
+        driver.connect("device-added", self.cb_device_added)
+        driver.probe(dev, {}, {})
+        self.mainloop()
+
+        assert self.ratbag_device is not None
+        device = self.ratbag_device
+        assert len(device.profiles) == roccat.MAX_PROFILES
+        assert device.profiles[0].active
+        for p in device.profiles:
+            assert len(p.resolutions) == 5
+            assert len(p.buttons) == roccat.MAX_BUTTONS
+
+            # buttons are 1, 2, ... etc.
+            act = p.buttons[0].action
+            assert act.type == ratbag.Action.Type.BUTTON
+            assert act.button == 1
+
+            act = p.buttons[1].action
+            assert act.type == ratbag.Action.Type.BUTTON
+            assert act.button == 2
+
+            # button value 9 (index 8) is the first special
+            act = p.buttons[8].action
+            assert act.type == ratbag.Action.Type.SPECIAL
+            assert act.special == ratbag.ActionSpecial.Special.WHEEL_LEFT
+
+    def test_init_buttons_cc_action_is_macro(self, driver):
+        # On init, driver converts ConsumerControl keys into a simple macro of
+        # press/release with a minimal wait in between
+        dev = RoccatTestDevice()
+        dev.profiles[1].buttons[5] = 36  # ConsumerControl.CC_STOP
+        driver.connect("device-added", self.cb_device_added)
+        driver.probe(dev, {}, {})
+        self.mainloop()
+
+        device = self.ratbag_device
+        act = device.profiles[1].buttons[5].action
+        assert act.type == ratbag.Action.Type.MACRO
+        macro = [
+            (ratbag.ActionMacro.Event.KEY_PRESS, libevdev.EV_KEY.KEY_STOP.value),
+            (ratbag.ActionMacro.Event.WAIT_MS, 1),
+            (ratbag.ActionMacro.Event.KEY_RELEASE, libevdev.EV_KEY.KEY_STOP.value),
+            (ratbag.ActionMacro.Event.WAIT_MS, 1),
+        ]
+        assert act.events == macro
+
+    def test_init_buttons_macro(self, driver):
+        # Set up an actual macro on a button, make sure it comes across
+        # correctly
+        kcA = ratbag.hid.Key.KEY_A.value
+        kcTab = ratbag.hid.Key.KEY_TAB.value
+        dev = RoccatTestDevice()
+        dev.profiles[0].buttons[2] = 48  # Macro
+        # a down, tab down, tab up, a up - with wait times in between
+        dev.profiles[0].macros[2] = [
+            (kcA, 0x01, 100),
+            (kcTab, 0x01, 200),
+            (kcTab, 0x00, 300),
+            (kcA, 0x00, 400),
+        ]
+        driver.connect("device-added", self.cb_device_added)
+        driver.probe(dev, {}, {})
+        self.mainloop()
+
+        device = self.ratbag_device
+        act = device.profiles[0].buttons[2].action
+        assert act.type == ratbag.Action.Type.MACRO
+        macro = [
+            (ratbag.ActionMacro.Event.KEY_PRESS, libevdev.EV_KEY.KEY_A.value),
+            (ratbag.ActionMacro.Event.WAIT_MS, 100),
+            (ratbag.ActionMacro.Event.KEY_PRESS, libevdev.EV_KEY.KEY_TAB.value),
+            (ratbag.ActionMacro.Event.WAIT_MS, 200),
+            (ratbag.ActionMacro.Event.KEY_RELEASE, libevdev.EV_KEY.KEY_TAB.value),
+            (ratbag.ActionMacro.Event.WAIT_MS, 300),
+            (ratbag.ActionMacro.Event.KEY_RELEASE, libevdev.EV_KEY.KEY_A.value),
+            (ratbag.ActionMacro.Event.WAIT_MS, 400),
+        ]
+        assert act.events == macro
+
+        # sanity check, we only configured one button to have a macro so let's
+        # make sure that is the case
+        for pidx, p in enumerate(device.profiles):
+            for bidx, b in enumerate(p.buttons):
+                if (pidx, bidx) == (0, 2):
+                    continue
+                assert b.action != ratbag.Action.Type.MACRO
+
+    def test_button_change_action(self, driver):
+        dev = RoccatTestDevice()
+        driver.connect("device-added", self.cb_device_added)
+        driver.probe(dev, {}, {})
+        self.mainloop()
+
+        device = self.ratbag_device
+        button = device.profiles[3].buttons[2]
+        button.set_action(ratbag.ActionButton(button, 1))  # change to left button
+        device.commit()
+        self.mainloop()
+
+        assert dev.profiles[3].buttons[2] == 1


### PR DESCRIPTION
The big ticket item here is of course the last commit which adds some tests for the roccat driver. Every driver *should* have those so we have less risk of breaking them if we refactor the library at some point.