### PR TITLE
Fix the hidpp20 to sort-of work again

### DIFF
--- a/tests/test_hidpp20.py
+++ b/tests/test_hidpp20.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: MIT
+#
+# This file is formatted with Python Black
+#
+
+
+import ratbag.drivers
+import ratbag.drivers.hidpp20 as hidpp20
+from ratbag.util import as_hex
+
+import pytest
+
+
+@pytest.fixture
+def driver():
+    return hidpp20.load_driver("hidpp20")
+
+
+def test_load_driver():
+    # the most basic test case...
+    assert hidpp20.load_driver("hidpp20") is not None
+    with pytest.raises(AssertionError):
+        hidpp20.load_driver("wrong-name")


### PR DESCRIPTION
This driver fell behind after all the recent revamps, let's fix it enough so it kinda works again.

Still incomplete, doesn't support writing back yet and the HID++ implementation is missing bits here and there. But hey, at least we can list the device without an exception now. 

cc @amfern

Closes #7 