### PR TITLE
parser: allow for fixed-length strings to be a format in Spec

### DIFF
--- a/ratbag/drivers/hidpp20.py
+++ b/ratbag/drivers/hidpp20.py
@@ -778,7 +778,9 @@ class Query(object):
             Spec("B", "command"),
         ] + self.reply_spec
 
-        result = Parser.to_object(bytes, spec)
+        # QueryFooBar should return a ResultFooBar class
+        replyname = type(self).__name__.replace("Query", "Result")
+        result = Parser.to_object(bytes, spec, result_class=replyname)
         return result.object
 
     def parse_reply(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -154,6 +154,38 @@ def test_parser():
         ]
         result = Parser.to_object(data, spec)
 
+    data = bytes(range(64, 73))
+    spec = [
+        Spec("B", "something"),
+        Spec("8s", "string", convert_from_data=lambda s: s.decode("utf-8")),
+    ]
+    result = Parser.to_object(data, spec)
+    assert result.size == len(data)
+    assert result.object.string == "ABCDEFGH"
+
+    data = bytes(range(64, 73))
+    spec = [
+        Spec("B", "something"),
+        Spec(
+            "2s",
+            "string",
+            repeat=4,
+            convert_from_data=lambda ss: list(s.decode("utf-8") for s in ss),
+        ),
+    ]
+    result = Parser.to_object(data, spec)
+    assert result.size == len(data)
+    assert result.object.string == ["AB", "CD", "EF", "GH"]
+
+    # Disallow anything but string repeats
+    with pytest.raises(AssertionError):
+        data = bytes(range(64, 73))
+        spec = [
+            Spec("B", "something"),
+            Spec("8B", "invalid"),
+        ]
+        result = Parser.to_object(data, spec)
+
 
 def test_data_files():
     datafiles = ratbag.util.load_data_files()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -186,6 +186,35 @@ def test_parser():
         ]
         result = Parser.to_object(data, spec)
 
+    # Test the class name for the reply object
+    data = bytes(range(64, 73))
+    spec = [Spec("B", "something")]
+    result = Parser.to_object(data, spec, result_class="Foo")
+    assert type(result.object).__name__ == "Foo"
+
+    # Test instantiating the right class for the reply object
+    class TestResult(object):
+        def __init__(self, something):
+            pass
+
+    result = Parser.to_object(data, spec, result_class=TestResult)
+    assert isinstance(result.object, TestResult)
+
+    # Passing a string creates a new class of that name, not our class
+    result = Parser.to_object(data, spec, result_class="TestResult")
+    assert not isinstance(result.object, TestResult)
+    assert type(result.object).__name__ == "TestResult"
+    obj1 = result.object
+
+    # Make sure we can do this with different specs
+    spec = [Spec("B", "other")]
+    result = Parser.to_object(data, spec, result_class="TestResult")
+    assert not isinstance(result.object, TestResult)
+    assert type(result.object).__name__ == "TestResult"
+    obj2 = result.object
+
+    assert type(obj1) != type(obj2)
+
 
 def test_data_files():
     datafiles = ratbag.util.load_data_files()


### PR DESCRIPTION
Instead of using `BBBBBB` and decoding from an int list, allow repeat
format specifiers in the spec itself, e.g. "5s" for a 5-byte string.

This is only permitted for the string format for now, in most other
cases an explicit `repeat=N` is more illustrative.