### PR TITLE
Improve ratbagd logging

### DIFF
--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -153,8 +153,12 @@ class Ratbag(GObject.Object):
 
         driver.connect("device-added", cb_device_added)
         if self._blackbox:
-            if "rodent-found" in GObject.signal_list_names(type(driver)):
+            try:
                 driver.connect("rodent-found", cb_rodent_found)
+            except (AttributeError, TypeError) as e:
+                logger.warning(
+                    "Signal 'rodent-found' not available, cannot record: {e}"
+                )
 
     def start(self) -> None:
         """

--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -56,13 +56,6 @@ class Ratbag(GObject.Object):
         is rarely a need for setting this to ``False`` outside specific test
         cases.
 
-    Supported keys in ``config``:
-
-    - ``emulators``: a list of :class:`ratbag.emulator.YamlDevice` or similar
-      to emulate a device
-    - ``recorders``: a list of :class:`ratbag.recorder.SimpleRecorder` or
-      similar to record device interactions
-
     GObject Signals:
 
     - ``device-added`` Notification that a new :class:`ratbag.Device` was added

--- a/ratbag/cli/ratbagcli.py
+++ b/ratbag/cli/ratbagcli.py
@@ -413,10 +413,6 @@ def _init_logger(conf=None, verbose=False):
         logging.basicConfig(format="%(levelname)s: %(name)s: %(message)s", level=lvl)
 
 
-def _init_recorders(outfile):
-    return [ratbag.recorder.YamlDeviceRecorder({"logfile": outfile})]
-
-
 def _init_emulators(infile):
     return [ratbag.emulator.YamlEmulator(infile)]
 

--- a/ratbag/cli/ratbagd.py
+++ b/ratbag/cli/ratbagd.py
@@ -14,9 +14,9 @@ from typing import List
 import dbus_next
 import logging
 import sys
+import os
 
 import ratbag
-from ratbag.driver import DeviceInfo
 
 logger = logging.getLogger("ratbagd")
 

--- a/ratbag/cli/ratbagd.py
+++ b/ratbag/cli/ratbagd.py
@@ -483,8 +483,15 @@ def init_logdir(path):
             xdg = Path.home() / ".local" / "state"
         else:
             xdg = Path("/") / "var" / "log"
-    logdir = Path(xdg) / "ratbagd" / datetime.datetime.now().strftime("%y-%m-%d-%H%M%S")
+    basedir = Path(xdg) / "ratbagd"
+    logdir = basedir / datetime.datetime.now().strftime("%y-%m-%d-%H%M%S")
     logdir.mkdir(exist_ok=True, parents=True)
+
+    latest = basedir / "latest"
+    if latest.is_symlink() or not latest.exists():
+        latest.unlink(missing_ok=True)
+        latest.symlink_to(logdir)
+
     return logdir
 
 

--- a/ratbag/cli/ratbagd.py
+++ b/ratbag/cli/ratbagd.py
@@ -31,6 +31,8 @@ def _init_logger(conf=None, verbose=False):
     if conf is None:
         conf = Path("config-logger.yml")
         if not conf.exists():
+            # FIXME: ratbagd will need to run as root, so XDG_CONFIG_HOME is
+            # probably not what you'd expect
             xdg = os.getenv("XDG_CONFIG_HOME")
             if xdg is None:
                 xdg = Path.home() / ".config"


### PR DESCRIPTION
Log all interactions with the device and keep the ratbagd log file around by default as well.

90% of the issues we face with libratbag is that our logs are insufficient to debug and debugging is a pain anyway, so let's work around this by default.