### PR TITLE
Make `git ls-files` calls take filter patterns directly

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ jobs:
           apt: $UBUNTU_PACKAGES
           pip: $PIP_PACKAGES
       - name: run Python black
-        run: git ls-files | grep ".py" | xargs black
+        run: git ls-files "*.py" | xargs black
       - name: diff for changes
         run: git diff --exit-code
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = doc/
 BUILDDIR      = build
-PYTHON_SOURCES	:= $(shell git ls-files | grep -e "\.py")
+PYTHON_SOURCES	:= $(shell git ls-files "*.py")
 
 
 all: data black pytest html data mypy doctest


### PR DESCRIPTION
Very small change. :)
There is no need to `grep` on the output, `ls-files` can actually filter
file names itself (even though it's not made obvious in it's manual page). In some way this is analogous to piping output of `cat` to `grep`, `grep` can actually read files directly.