### PR TITLE
Switch the public API to use python attrs

### DIFF
--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -103,17 +103,18 @@ class Ratbag(GObject.Object):
         datafiles = ratbag.util.load_data_files()
 
         # drivers want the list of all entries passed as one, so we need to
-        # extract them first, into a dict of "drivername" : [dev1, dev2, ...]
+        # extract them first, into a dict of
+        # "drivername" : [DeviceConfig(match1), DeviceConfig(match2), ...]
         drivers: Dict[str, List["ratbag.driver.DeviceConfig"]] = {}
         for f in datafiles:
-            for match in f.matches:
-                supported_devices = drivers.get(f.driver, [])
-                supported_devices.append(DeviceConfig(match, f.driver_options))
-                drivers[f.driver] = supported_devices
+            supported_devices = [
+                DeviceConfig(match, f.driver_options) for match in f.matches
+            ]
+            drivers[f.driver] = drivers.get(f.driver, []).extend(supported_devices)
 
-        for drivername, supported_devices in drivers.items():
+        for drivername, configs in drivers.items():
             try:
-                self.add_driver(drivername, supported_devices)
+                self.add_driver(drivername, configs)
             except ratbag.driver.DriverUnavailable as e:
                 logger.error(f"{e}")
 

--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -235,6 +235,7 @@ class Blackbox:
         return cls(directory=directory)
 
 
+@attr.s
 class Recorder(GObject.Object):
     """
     Recorder can be added to a :class:`ratbag.Driver` to log data between the
@@ -243,7 +244,7 @@ class Recorder(GObject.Object):
     :param config: A dictionary with logger-specific data to initialize
     """
 
-    def __init__(self, config: Dict[str, Any] = {}):
+    def __attrs_pre_init__(self):
         GObject.Object.__init__(self)
 
     def log_rx(self, data: bytes) -> None:

--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -163,7 +163,7 @@ class Ratbag(GObject.Object):
     def start(self) -> None:
         """
         Start the context. Before invoking this function ensure the caller has
-        connected to all the signal.
+        connected to all the signals.
         """
         self.emit("start")
 

--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -216,6 +216,10 @@ class Blackbox:
         """
         return self.directory / filename
 
+    @classmethod
+    def create(cls, directory: Path) -> "Blackbox":
+        return cls(directory=directory)
+
 
 class Recorder(GObject.Object):
     """
@@ -353,7 +357,6 @@ class Device(GObject.Object):
 
     @classmethod
     def create(cls, driver: "ratbag.driver.Driver", path: str, name: str, **kwargs):
-
         permitted = ["firmware_version", "model"]
 
         filtered = {k: v for k, v in kwargs.items() if k in permitted}

--- a/ratbag/cli/ratbagcli.py
+++ b/ratbag/cli/ratbagcli.py
@@ -269,7 +269,7 @@ class Config(object):
                 else:
                     logger.debug("done")
 
-            transaction = ratbag.CommitTransaction()
+            transaction = ratbag.CommitTransaction.create()
             transaction.connect("finished", cb_commit_finished)
 
             device.commit(transaction)

--- a/ratbag/cli/ratbagcli.py
+++ b/ratbag/cli/ratbagcli.py
@@ -443,7 +443,7 @@ def ratbagcli(ctx, verbose: int, log_config: Path, record: Path, replay: Path):
 
     ctx.obj = {}
     if record:
-        ctx.obj["blackbox"] = ratbag.Blackbox(directory=record)
+        ctx.obj["blackbox"] = ratbag.Blackbox.create(directory=record)
     if replay:
         ctx.obj["emulators"] = _init_emulators(replay)
 

--- a/ratbag/cli/ratbagd.py
+++ b/ratbag/cli/ratbagd.py
@@ -543,7 +543,7 @@ def main():
     init_logger(levels, logdir)
     kwargs = {}
     if not ns.disable_recordings:
-        blackbox = ratbag.Blackbox(directory=logdir)
+        blackbox = ratbag.Blackbox.create(directory=logdir)
         kwargs["blackbox"] = blackbox
     rb = ratbag.Ratbag.create(**kwargs)
     ratbagd = Ratbagd(rb)

--- a/ratbag/drivers/example_driver.py
+++ b/ratbag/drivers/example_driver.py
@@ -55,7 +55,7 @@ class ExampleDriver(ratbag.driver.Driver):
         self.probe("my device", "/some/path")
 
     def probe(self, name, path):
-        device = ratbag.Device(self, path, name)
+        device = ratbag.Device.create(self, path, name)
         device.connect("commit", self._on_commit)
 
         for profile_idx in range(3):  # three profiles

--- a/ratbag/drivers/hidpp20.py
+++ b/ratbag/drivers/hidpp20.py
@@ -653,7 +653,7 @@ class Hidpp20Driver(ratbag.driver.HidrawDriver):
         device = Hidpp20Device(rodent, index)
 
         device.start()
-        ratbag_device = ratbag.Device(
+        ratbag_device = ratbag.Device.create(
             self,
             path=device.path,
             name=device.name,

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -161,7 +161,7 @@ class RoccatProfile(object):
         for (dpi_idx, dpi) in enumerate(self.dpi):
             dpi_list = tuple(range(200, 8200 + 1, 50))
             caps = [ratbag.Resolution.Capability.SEPARATE_XY_RESOLUTION]
-            ratbag.Resolution(
+            ratbag.Resolution.create(
                 p,
                 dpi_idx,
                 dpi,
@@ -177,7 +177,7 @@ class RoccatProfile(object):
                 ratbag.Action.Type.MACRO,
             ]
             action = self.key_mapping.button_to_ratbag(btn_idx)
-            ratbag.Button(p, btn_idx, types=caps, action=action)
+            ratbag.Button.create(p, btn_idx, types=caps, action=action)
 
         self.ratbag_profile = p
         return p
@@ -480,20 +480,22 @@ class RoccatKeyMapping(object):
         action = self.actions[idx][0]
         macro = self.macros.get(idx, None)
         if action == 0:
-            ratbag_action = ratbag.ActionNone()
+            ratbag_action = ratbag.ActionNone.create()
         elif action in [1, 2, 3]:
-            ratbag_action = ratbag.ActionButton(action)
+            ratbag_action = ratbag.ActionButton.create(action)
         # 5 is shortcut (modifier + key)
         elif action == 6:
-            ratbag_action = ratbag.ActionNone()
+            ratbag_action = ratbag.ActionNone.create()
         elif action in [7, 8]:
-            ratbag_action = ratbag.ActionButton(action - 3)
+            ratbag_action = ratbag.ActionButton.create(action - 3)
         elif action in RoccatKeyMapping.specials:
-            ratbag_action = ratbag.ActionSpecial(RoccatKeyMapping.specials[action])
+            ratbag_action = ratbag.ActionSpecial.create(
+                RoccatKeyMapping.specials[action]
+            )
         elif action == 48:
             assert macro is not None
             name, events = macro.to_ratbag()
-            ratbag_action = ratbag.ActionMacro(name, events)
+            ratbag_action = ratbag.ActionMacro.create(name=name, events=events)
         else:
             # For keycodes we pretend it's a macro
             assert macro is None
@@ -507,10 +509,10 @@ class RoccatKeyMapping(object):
                 ]
                 macro.length = 2
                 name, events = macro.to_ratbag()
-                ratbag_action = ratbag.ActionMacro(name, events)
+                ratbag_action = ratbag.ActionMacro.create(name=name, events=events)
             except KeyError:
                 logger.info(f"Unsupported action type {action}")
-                ratbag_action = ratbag.Action()
+                ratbag_action = ratbag.ActionUnknown.create()
         return ratbag_action
 
     def button_update_from_ratbag(self, idx, ratbag_action):

--- a/ratbag/drivers/roccat.py
+++ b/ratbag/drivers/roccat.py
@@ -580,8 +580,8 @@ class RoccatDevice(GObject.Object):
         self.driver = driver
         self.hidraw_device = rodent
         self.profiles = []
-        self.ratbag_device = ratbag.Device(
-            self.driver, self.path, self.name, rodent.model
+        self.ratbag_device = ratbag.Device.create(
+            self.driver, self.path, self.name, model=rodent.model
         )
         self.ratbag_device.connect("commit", self.cb_commit)
 

--- a/ratbag/util.py
+++ b/ratbag/util.py
@@ -144,3 +144,17 @@ def load_data_files() -> List[DataFile]:
         raise FileNotFoundError("Unable to find data files")
 
     return files
+
+
+def to_tuple(x) -> Tuple:
+    try:
+        return tuple(set(x))
+    except TypeError as e:
+        raise ValueError("Invalid value: {e}")
+
+
+def to_sorted_tuple(x) -> Tuple:
+    try:
+        return tuple(sorted(set(x)))
+    except TypeError as e:
+        raise ValueError("Invalid value: {e}")

--- a/tests/test_ratbag.py
+++ b/tests/test_ratbag.py
@@ -17,38 +17,38 @@ def device():
 
 
 def test_resolution(device):
-    profile = ratbag.Profile(device, 0)
+    profile = ratbag.Profile.create(device, 0)
 
     # invalid index
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, -1, (0, 0))
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, -1, (0, 0))
 
     # negative dp
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, (-1, -1))
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, 0, (-1, -1))
 
     # dpi not an int
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, ("asbc", 1))
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, 0, ("asbc", 1))
 
     # dpi not a 2-value tuple
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, (1, 2, 3))
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, 0, (1, 2, 3))
 
     # dpi list negative
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, (1, 2), dpi_list=[-1])
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, 0, (1, 2), dpi_list=[-1])
 
     # dpi list not a list
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, (1, 2), dpi_list=-1)
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, 0, (1, 2), dpi_list=-1)
 
     # capability not in the enum
-    with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, (1, 2, 3), capabilities=[1])
+    with pytest.raises(ValueError):
+        ratbag.Resolution.create(profile, 0, (1, 2), capabilities=[1])
 
     # default values
-    r = ratbag.Resolution(profile, 0, (200, 200))
+    r = ratbag.Resolution.create(profile, 0, (200, 200))
     assert r.capabilities == ()
     assert not r.active
     assert not r.default
@@ -63,10 +63,10 @@ def test_resolution(device):
 
     # duplicate index
     with pytest.raises(AssertionError):
-        ratbag.Resolution(profile, 0, (200, 200))
+        ratbag.Resolution.create(profile, 0, (200, 200))
 
     # caps assigned properly?
-    r = ratbag.Resolution(
+    r = ratbag.Resolution.create(
         profile,
         1,
         (200, 200),
@@ -83,7 +83,7 @@ def test_resolution_set_default(device):
     for i in range(5):
         profile = ratbag.Profile(device, i)
         for j in range(5):
-            ratbag.Resolution(profile, j, (j * 100, j * 100))
+            ratbag.Resolution.create(profile, j, (j * 100, j * 100))
 
     r11 = device.profiles[1].resolutions[1]
     r13 = device.profiles[1].resolutions[3]
@@ -135,7 +135,7 @@ def test_resolution_set_active(device):
     for i in range(5):
         profile = ratbag.Profile(device, i)
         for j in range(5):
-            ratbag.Resolution(profile, j, (j * 100, j * 100))
+            ratbag.Resolution.create(profile, j, (j * 100, j * 100))
 
     r11 = device.profiles[1].resolutions[1]
     r13 = device.profiles[1].resolutions[3]
@@ -185,7 +185,7 @@ def test_resolution_set_active(device):
 
 def test_led(device):
     profile = ratbag.Profile(device, 0)
-    led = ratbag.Led(profile, 0)
+    led = ratbag.Led.create(profile, 0)
 
     # color checks
     invalid_colors = [
@@ -242,7 +242,9 @@ def test_led(device):
 
     # LED modes
     assert led.modes == (ratbag.Led.Mode.OFF,)
-    led = ratbag.Led(profile, 1, modes=tuple(ratbag.Led.Mode), mode=ratbag.Led.Mode.ON)
+    led = ratbag.Led.create(
+        profile, 1, modes=tuple(ratbag.Led.Mode), mode=ratbag.Led.Mode.ON
+    )
     assert led.modes == tuple(ratbag.Led.Mode)
     for m in led.modes:
         led.set_mode(m)
@@ -340,37 +342,37 @@ def test_profile_out_of_order(device):
 
 
 def test_action_equals():
-    assert ratbag.Action() == ratbag.Action()
-    assert ratbag.Action() != ratbag.ActionButton(1)
-    assert ratbag.Action() != ratbag.ActionSpecial(
+    assert ratbag.ActionUnknown.create() == ratbag.ActionUnknown.create()
+    assert ratbag.ActionUnknown.create() != ratbag.ActionButton.create(1)
+    assert ratbag.ActionUnknown.create() != ratbag.ActionSpecial.create(
         ratbag.ActionSpecial.Special.DOUBLECLICK
     )
 
-    assert ratbag.ActionButton(1) == ratbag.ActionButton(1)
-    assert ratbag.ActionButton(2) != ratbag.ActionButton(1)
-    assert ratbag.ActionButton(1) != ratbag.ActionSpecial(
+    assert ratbag.ActionButton.create(1) == ratbag.ActionButton.create(1)
+    assert ratbag.ActionButton.create(2) != ratbag.ActionButton.create(1)
+    assert ratbag.ActionButton.create(1) != ratbag.ActionSpecial.create(
         ratbag.ActionSpecial.Special.DOUBLECLICK
     )
 
-    assert ratbag.ActionSpecial(
+    assert ratbag.ActionSpecial.create(
         ratbag.ActionSpecial.Special.DOUBLECLICK
-    ) == ratbag.ActionSpecial(ratbag.ActionSpecial.Special.DOUBLECLICK)
-    assert ratbag.ActionSpecial(
+    ) == ratbag.ActionSpecial.create(ratbag.ActionSpecial.Special.DOUBLECLICK)
+    assert ratbag.ActionSpecial.create(
         ratbag.ActionSpecial.Special.WHEEL_DOWN
-    ) != ratbag.ActionSpecial(ratbag.ActionSpecial.Special.DOUBLECLICK)
+    ) != ratbag.ActionSpecial.create(ratbag.ActionSpecial.Special.DOUBLECLICK)
 
     # name is not checked for equality
-    assert ratbag.ActionMacro(
+    assert ratbag.ActionMacro.create(
         name="foo", events=[(ratbag.ActionMacro.Event.KEY_PRESS, 1)]
-    ) == ratbag.ActionMacro(
+    ) == ratbag.ActionMacro.create(
         name="bar", events=[(ratbag.ActionMacro.Event.KEY_PRESS, 1)]
     )
-    assert ratbag.ActionMacro(
+    assert ratbag.ActionMacro.create(
         name="foo",
         events=[
             (ratbag.ActionMacro.Event.KEY_PRESS, 1),
             (ratbag.ActionMacro.Event.KEY_PRESS, 2),
         ],
-    ) != ratbag.ActionMacro(
+    ) != ratbag.ActionMacro.create(
         name="bar", events=[(ratbag.ActionMacro.Event.KEY_PRESS, 1)]
     )

--- a/tests/test_roccat.py
+++ b/tests/test_roccat.py
@@ -322,7 +322,7 @@ class TestRoccatDriver(object):
 
         device = self.ratbag_device
         button = device.profiles[3].buttons[2]
-        button.set_action(ratbag.ActionButton(1))  # change to left button
+        button.set_action(ratbag.ActionButton.create(1))  # change to left button
 
         transaction = new_transaction(device)
         transaction.commit()

--- a/tests/test_roccat.py
+++ b/tests/test_roccat.py
@@ -38,9 +38,8 @@ ff 7f 95 02 75 10 81 06 09 38 15 81 25 7f 75 08 95 01 81 06 05 0c 0a 38 02 81
 )
 
 
-@pytest.fixture
-def transaction():
-    transaction = ratbag.CommitTransaction()
+def new_transaction(device):
+    transaction = ratbag.CommitTransaction.create(device)
 
     def cb_finished(ta):
         assert ta.is_finished
@@ -314,7 +313,7 @@ class TestRoccatDriver(object):
                     continue
                 assert b.action != ratbag.Action.Type.MACRO
 
-    def test_button_change_action(self, driver, transaction):
+    def test_button_change_action(self, driver):
         dev = RoccatTestDevice()
         driver.connect("device-added", self.cb_device_added)
         # Note: we bypass the hidraw monitor because we don't need it
@@ -324,13 +323,15 @@ class TestRoccatDriver(object):
         device = self.ratbag_device
         button = device.profiles[3].buttons[2]
         button.set_action(ratbag.ActionButton(1))  # change to left button
-        device.commit(transaction)
+
+        transaction = new_transaction(device)
+        transaction.commit()
         self.mainloop()
 
         assert transaction.success is True
         assert dev.profiles[3].buttons[2] == 1
 
-    def test_dpi_change(self, driver, transaction):
+    def test_dpi_change(self, driver):
         dev = RoccatTestDevice()
         driver.connect("device-added", self.cb_device_added)
         # Note: we bypass the hidraw monitor because we don't need it
@@ -342,7 +343,8 @@ class TestRoccatDriver(object):
         res.set_dpi((1300, 1300))
         res = device.profiles[1].resolutions[1]
         res.set_dpi((1400, 1400))
-        device.commit(transaction)
+        transaction = new_transaction(device)
+        transaction.commit()
         self.mainloop()
 
         assert transaction.success is True


### PR DESCRIPTION
In most instances this makes the code more readable since all attributes are defined in the class (rather than hidden away in the constructor or, worse, later somewhere). In some cases it's a bit more awkward but for consistency this is probably an improvement