### PR TITLE
ratbag: fix the driver loading again

### DIFF
--- a/ratbag/__init__.py
+++ b/ratbag/__init__.py
@@ -128,7 +128,7 @@ class Ratbag(GObject.Object):
             supported_devices = [
                 DeviceConfig(match, f.driver_options) for match in f.matches
             ]
-            drivers[f.driver] = drivers.get(f.driver, []).extend(supported_devices)
+            drivers[f.driver] = drivers.setdefault(f.driver, []) + supported_devices
 
         for drivername, configs in drivers.items():
             try:


### PR DESCRIPTION
list.extend returns None, so this would set the driver list to None.
And I had it locally, just didn't get squashed in in time.

Fixes 478d9d695be0252bd31599893239fc02e1958abd