### PR TITLE
Add a udev rule + hwdb file generator for uaccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ devices. This means you need to run any tool as root or, alternatively and
 even less secure: `chmod o+rw /dev/hidrawN` where `N` is the number of your
 device.
 
+This repo ships with a udev rule/hwdb that enables uaccess on all known ratbag
+devices, i.e. allowing the logged-in user to access hidraw devices without
+having to be root. To enable this on your machine, run this in the repository:
+
+```
+$ ./udev/ratbag-generate-hwdb
+$ sudo cp udev/80-ratbag.rules /etc/udev/rules.d
+$ sudo cp udev/80-ratbag.hwdb /etc/udev/hwdb.d
+$ sudo systemd-hwdb update
+```
+
+This needs to be done before plugging in your device.
+
 ### ratbagcli
 
 This package provides the `ratbagcli` commandline tool to interact with a

--- a/udev/80-ratbag.hwdb.in
+++ b/udev/80-ratbag.hwdb.in
@@ -1,0 +1,22 @@
+# This file is generated, it will be overritten on update
+#
+# Put this file in /etc/udev/hwdb.d/ and run systemd-hwdb update before plugging in your device.
+#
+# The lookup keys are composed in 80-ratbag.rules
+#
+# After changing entries in this file (or installing a new version of this
+# file) run: sudo systemd-hwdb update
+# Then unplug your device and plug it back in again.
+#
+# To add local entries for testing, create a new file
+#   /etc/udev/hwdb.d/81-ratbag-local.hwdb
+# and add a rule there. Look at the modalias file for your device
+#   /sys/class/hidraw/hidraw0/device/modalias
+# for the string we match against. That string contains three keys that matter:
+# 'b' is the zero-prefixed 4-digit uppercase hex bus type (3 for usb or 5 for bluetooth)
+# 'v' for the zero-prefixed 8-digit uppercase hex vendor id
+# 'p' for the zero-prefixed 8-digit uppercase hex product id
+#
+# Ignore the 'g' key, use "g*" in the hwd entry.
+
+@GENERATED_HWDB_ENTRIES@

--- a/udev/80-ratbag.rules
+++ b/udev/80-ratbag.rules
@@ -1,0 +1,15 @@
+# This file is part of rattlesnake
+#
+# Put this file in /etc/udev/rules.d/
+
+ACTION=="remove", GOTO="ratbag_end"
+
+# Devices that match our hwdb get the uaccess tag applied, i.e. they can be accessed by
+# a logged-in user without a password required.
+#
+# Note that this makes it possible for keyboard sniffers to run under your
+# username, so use this with the appropriate caution.
+IMPORT{builtin}="hwdb --subsystem=hid --lookup-prefix=ratbag:"
+ENV{RATBAG_DEVICE}=="1", TAG+="uaccess"
+
+LABEL="ratbag_end"

--- a/udev/ratbag-generate-hwdb
+++ b/udev/ratbag-generate-hwdb
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# This file is formatted with Python black
+
+import argparse
+import configparser
+import logging
+from pathlib import Path
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(Path(__file__).name)
+
+script_dir = Path(__file__).absolute().parent
+
+parser = argparse.ArgumentParser("Tool to generate hwdb entries")
+parser.add_argument("--template", type=Path, default=script_dir / "80-ratbag.hwdb.in")
+parser.add_argument("--verbose", action='count', default=0)
+parser.add_argument("--datadir", type=Path, default=script_dir / ".." / "data" / "devices")
+
+ns = parser.parse_args()
+logger.setLevel(logging.DEBUG if ns.verbose else logging.INFO)
+
+hwdb = {}
+
+class Entry:
+    def __init__(self, busname, vidstr, pidstr):
+        self.name = name
+        self.bus = {
+                "usb": "0003",
+                "bluetooth": "0005",
+        }[busname]
+        vid = int(vidstr, 16)
+        self.vid = f"{vid:08X}" if vid else "00000000"
+        pid = int(pidstr, 16)
+        self.pid = f"{pid:08X}" if pid else "00000000"
+
+    @property
+    def matchstr(self):
+        return f"ratbag:hid:b{self.bus}g*v{self.vid}p{self.pid}"
+
+logger.debug(f"Data directory is {ns.datadir}")
+
+for file in ns.datadir.glob("*.device"):
+    logger.debug(f"Parsing {file}")
+
+    c = configparser.ConfigParser()
+    c.read(file)
+
+    sect = c["Device"]
+
+    match = sect["DeviceMatch"]
+    name = sect["Name"]
+    matches = match.split(";")
+
+    entries = hwdb.get(name, [])
+
+    for m in matches:
+        bus, vid, pid = m.split(":")
+        entries.append(Entry(bus, vid, pid))
+
+    hwdb[name] = entries
+
+outfile = ns.template.stem
+if not outfile.endswith(".hwdb"):
+    outfile = f"{outfile}.hwdb"
+
+logger.debug(f"Writing to {outfile}")
+
+with open(ns.template) as infile:
+    with open(Path(ns.template.parent) / outfile, "w") as outfile:
+        for line in infile:
+            if "@GENERATED_HWDB_ENTRIES@" not in line:
+                outfile.write(line)
+                continue
+
+            for name in sorted(hwdb.keys()):
+                entries = hwdb[name]
+                print(f"\n# {name}", file=outfile)
+                for e in entries:
+                    print(f"{e.matchstr}", file=outfile)
+                print(" RATBAG_DEVICE=1", file=outfile)
+
+            outfile.flush()
+


### PR DESCRIPTION
This script enables us to generate a hwdb file of all devices in our data base. The hwdb file simply sets RATBAG_DEVICE=1, the accompanying udev file applies the uaccess tag which means the device is readable by a logged-in user. No more need to run ratbag* as root. With all the other security issues that implies of course.